### PR TITLE
fix for when func is none

### DIFF
--- a/scripts/list_avd.py
+++ b/scripts/list_avd.py
@@ -7,4 +7,7 @@ func = os.getenv("func")
 
 shell_cmd = "{0} -avd {1} {2}".format(emulator_path, sys.argv[1], func)
 
+if func is None:
+  shell_cmd = "{0} -avd {1}".format(emulator_path, sys.argv[1])
+
 result = run_script(shell_cmd)


### PR DESCRIPTION
While trying to run de `avd` command, I was getting the following error:

```
invalid command-line parameter: None.
Hint: use '@foo' to launch a virtual device named 'foo'.
please use -help for more information
```

because in the end, a `None` was being added.

I did a verification to solve that